### PR TITLE
smppi 경량화: 죽은 파이프라인 제거 + 옵티마이저/시각화 발행 최적화

### DIFF
--- a/controller/smppi/scripts/visualization_node.py
+++ b/controller/smppi/scripts/visualization_node.py
@@ -5,6 +5,7 @@ Handles all RViz visualization without impacting control performance
 Subscribes to processed data, publishes markers and visualization
 """
 
+import math
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy
@@ -521,7 +522,6 @@ class VisualizationNode(Node):
             heading_marker.pose.position.z = 0.3  # Above robot footprint
             
             # Orientation from robot yaw
-            import math
             heading_marker.pose.orientation.w = math.cos(robot_yaw / 2.0)
             heading_marker.pose.orientation.z = math.sin(robot_yaw / 2.0)
             


### PR DESCRIPTION
- costmap_processor/sensor_processor 노드 삭제: ProcessedObstacles는 크리틱 미사용 (costmap 텐서 방식으로 대체된 지 오래), odom→MPPIState 100Hz 릴레이는 main/viz의 /odom 직구독(BEST_EFFORT)으로 대체 (RobotState 어댑터, 사용처 무수정)
- 레거시 smppi_controller_node 및 전용 유틸 삭제, 미사용 msg(ProcessedObstacles, MPPIState) 제거 — msg 제거로 재빌드 시 build/install 클린 필요
- optimizer: eps=noise 등가 치환(repeat/차분 제거), omega device 상주(H2D/사이클 제거), get_control_command 동기화 4회→1회 + 미사용 clone 제거
- 시각화 발행 게이트: enable_visualization AND viz 주기 데시메이션(10→5Hz) AND 구독자 존재 시에만 optimal_path/lookahead 발행 (rollout 중복 실행 방지)
- is_ready를 costmap 수신 기반으로 변경 (구 obstacles 게이트 대체)